### PR TITLE
Fixed repo url in package.json

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,6 @@ jobs:
       - run: npm ci
       - name: Set version
         run: npm version --no-git-tag-version ${{github.event.release.tag_name}}
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CodingBullDev/story-gpt.git"
+    "url": "git+https://github.com/CodingBull-dev/story-gpt.git"
   },
   "keywords": [
     "OpenAI",


### PR DESCRIPTION
It was pointing to the wrong url because of a typo.

I also re-enabled the provenance parameter in npm publish. It should work now.