### PR TITLE
Migrate npm publish to OIDC Trusted Publishers

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
   publish:
     name: Build & Publish to NPM
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -25,5 +26,3 @@ jobs:
       - name: Set version
         run: npm version --no-git-tag-version ${{github.event.release.tag_name}}
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `NPM_TOKEN` secret — authentication is now handled via GitHub OIDC (Trusted Publishers)
- Adds `environment: npm` to the publish job, matching the npm Trusted Publisher configuration
- `id-token: write` permission was already in place

## Test plan

- [ ] Trigger a release and confirm the publish job authenticates via OIDC without `NPM_TOKEN`
- [ ] Verify the `npm` environment exists in GitHub repo settings (Settings → Environments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)